### PR TITLE
Sighandler reinstall for Wasmer 2

### DIFF
--- a/lib/vm/src/trap/mod.rs
+++ b/lib/vm/src/trap/mod.rs
@@ -11,4 +11,4 @@ pub use traphandlers::{
     catch_traps, catch_traps_with_result, raise_lib_trap, raise_user_trap, wasmer_call_trampoline,
     TlsRestore, Trap, TrapHandler, TrapHandlerFn,
 };
-pub use traphandlers::{force_init_traps, init_traps, resume_panic};
+pub use traphandlers::{init_traps, platform_init, resume_panic};

--- a/lib/vm/src/trap/mod.rs
+++ b/lib/vm/src/trap/mod.rs
@@ -11,4 +11,4 @@ pub use traphandlers::{
     catch_traps, catch_traps_with_result, raise_lib_trap, raise_user_trap, wasmer_call_trampoline,
     TlsRestore, Trap, TrapHandler, TrapHandlerFn,
 };
-pub use traphandlers::{init_traps, resume_panic};
+pub use traphandlers::{force_init_traps, init_traps, resume_panic};

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -42,7 +42,8 @@ cfg_if::cfg_if! {
         static mut PREV_SIGILL: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
         static mut PREV_SIGFPE: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
 
-        unsafe fn platform_init() {
+        /// Attach handlers to OS signals
+        pub unsafe fn platform_init() {
             let register = |slot: &mut MaybeUninit<libc::sigaction>, signal: i32| {
                 let mut handler: libc::sigaction = mem::zeroed();
                 // The flags here are relatively careful, and they are...
@@ -394,12 +395,6 @@ pub fn init_traps(is_wasm_pc: fn(usize) -> bool) {
         IS_WASM_PC = is_wasm_pc;
         platform_init();
     });
-}
-
-/// This function calls platform_init() without wrapping it in Once.
-#[allow(dead_code)]
-pub fn force_init_traps() {
-    unsafe { platform_init() }
 }
 
 /// Raises a user-defined trap immediately.

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -396,6 +396,12 @@ pub fn init_traps(is_wasm_pc: fn(usize) -> bool) {
     });
 }
 
+/// This function calls platform_init() without wrapping it in Once.
+#[allow(dead_code)]
+pub fn force_init_traps() {
+    unsafe { platform_init() }
+}
+
 /// Raises a user-defined trap immediately.
 ///
 /// This function performs as-if a wasm trap was just executed, only the trap


### PR DESCRIPTION
This PR changes `wasmer::vm::traphandlers::platform_init()` to make it publicly callable and to add protection against overwriting its `PREV_` sigactions when called repeatedly.