### PR TITLE
Sighandler reinstall for Wasmer 1

### DIFF
--- a/lib/runtime-c-api/src/signals.rs
+++ b/lib/runtime-c-api/src/signals.rs
@@ -1,8 +1,14 @@
-use wasmer_runtime_core::fault::SIGSEGV_PASSTHROUGH;
 use std::sync::atomic::Ordering;
+use wasmer_runtime_core::fault::{install_sighandler_as_dylib, SIGSEGV_PASSTHROUGH};
 
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_set_sigsegv_passthrough() {
     SIGSEGV_PASSTHROUGH.swap(true, Ordering::SeqCst);
+}
+
+#[allow(clippy::cast_ptr_alignment)]
+#[no_mangle]
+pub unsafe extern "C" fn wasmer_force_install_sighandlers() {
+    install_sighandler_as_dylib();
 }

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -645,6 +645,8 @@ wasmer_export_t *wasmer_exports_get(wasmer_exports_t *exports, int idx);
  */
 int wasmer_exports_len(wasmer_exports_t *exports);
 
+void wasmer_force_install_sighandlers(void);
+
 /**
  * Frees memory for the given Global
  */

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -514,6 +514,8 @@ wasmer_export_t *wasmer_exports_get(wasmer_exports_t *exports, int idx);
 /// Gets the length of the exports
 int wasmer_exports_len(wasmer_exports_t *exports);
 
+void wasmer_force_install_sighandlers();
+
 /// Frees memory for the given Global
 void wasmer_global_destroy(wasmer_global_t *global);
 

--- a/lib/runtime-core/src/fault.rs
+++ b/lib/runtime-core/src/fault.rs
@@ -476,7 +476,8 @@ unsafe fn install_sighandler() {
     sigaction(SIGINT, &sa_interrupt).unwrap();
 }
 
-unsafe fn install_sighandler_as_dylib() {
+/// Install signal handlers, normally called once per process.
+pub unsafe fn install_sighandler_as_dylib() {
     let sa_trap = SigAction::new(
         SigHandler::SigAction(signal_trap_handler),
         SaFlags::SA_ONSTACK,


### PR DESCRIPTION
This PR adds a new C API function, `wasmer_force_install_sighandlers()`, which repeats the installation of Wasmer-specific signal handlers. Because it's a stateless operation, it can be performed repeatedly.